### PR TITLE
Add theme logger to debug missing styles

### DIFF
--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -5,6 +5,7 @@ import "./globals.css"
 import "../styles/animations.css"
 import "../styles/components.css"
 import { cn } from "@/lib/utils"
+import ThemeLogger from "@/components/theme-logger"
 
 const inter = Inter({
   subsets: ["latin"],
@@ -108,6 +109,7 @@ export default function RootLayout({
         <meta name="msapplication-TileColor" content="#a855f7" />
       </head>
       <body className={cn("min-h-screen bg-background font-sans antialiased", inter.variable, jetbrainsMono.variable)}>
+        <ThemeLogger />
         <div id="root">{children}</div>
         <div id="portal-root" />
       </body>

--- a/frontend/components/theme-logger.tsx
+++ b/frontend/components/theme-logger.tsx
@@ -1,0 +1,27 @@
+"use client"
+
+import { useEffect } from "react"
+
+const variables = [
+  "--background",
+  "--foreground",
+  "--primary",
+  "--secondary",
+  "--accent",
+]
+
+export default function ThemeLogger() {
+  useEffect(() => {
+    const styles = getComputedStyle(document.documentElement)
+    const logged: Record<string, string> = {}
+
+    for (const variable of variables) {
+      logged[variable] = styles.getPropertyValue(variable).trim()
+    }
+
+    console.log("[ThemeLogger] CSS variables:", logged)
+  }, [])
+
+  return null
+}
+


### PR DESCRIPTION
## Summary
- log key CSS variables in a new `ThemeLogger` component
- mount `ThemeLogger` in the root layout to surface runtime style issues

## Testing
- `npm run lint` *(requires configuration)*
- `npm run type-check` *(fails: Cannot find module '@/components/ui/skeleton')*

------
https://chatgpt.com/codex/tasks/task_e_68976fb79694832f85dbf33f0a766433