### PR TITLE
feat(auth): add role-based authorization

### DIFF
--- a/backend/middleware/authorize.js
+++ b/backend/middleware/authorize.js
@@ -1,0 +1,10 @@
+const authorize = (...allowedRoles) => {
+  return (req, res, next) => {
+    if (!req.user || !allowedRoles.includes(req.user.role)) {
+      return res.status(403).json({ msg: "Accès interdit: rôle insuffisant" })
+    }
+    next()
+  }
+}
+
+module.exports = authorize

--- a/backend/routes/users.js
+++ b/backend/routes/users.js
@@ -3,9 +3,10 @@ const router = express.Router()
 const bcrypt = require("bcryptjs")
 const db = require("../config/db")
 const auth = require("../middleware/auth")
+const authorize = require("../middleware/authorize")
 
 // Obtenir tous les utilisateurs
-router.get("/", auth, async (req, res) => {
+router.get("/", auth, authorize("Admin", "DPO", "SuperAdmin"), async (req, res) => {
   try {
     const [users] = await db.query("SELECT id, nom, role, email, actif, cree_le FROM Utilisateur ORDER BY nom")
     res.json(users)
@@ -16,7 +17,7 @@ router.get("/", auth, async (req, res) => {
 })
 
 // Créer un utilisateur
-router.post("/", auth, async (req, res) => {
+router.post("/", auth, authorize("Admin", "DPO", "SuperAdmin"), async (req, res) => {
   const { nom, role, email, mot_de_passe } = req.body
 
   try {
@@ -49,7 +50,7 @@ router.post("/", auth, async (req, res) => {
 })
 
 // Mettre à jour un utilisateur
-router.put("/:id", auth, async (req, res) => {
+router.put("/:id", auth, authorize("Admin", "DPO", "SuperAdmin"), async (req, res) => {
   const { nom, role, email, actif } = req.body
 
   try {

--- a/database/add_superadmin_role.sql
+++ b/database/add_superadmin_role.sql
@@ -1,0 +1,4 @@
+ALTER TABLE Utilisateur MODIFY role ENUM('DPO','Admin','Collaborateur','SuperAdmin') NOT NULL;
+
+INSERT INTO Utilisateur (nom, role, email, mot_de_passe) VALUES
+('Super Admin', 'SuperAdmin', 'super.admin@example.com', '$2a$10$DM29GNklacafTPWB.8BpIeDDJxMc8gri6uPvJkl3OEYAdCYDxFGDi');

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -8,7 +8,7 @@ USE smart_dpo;
 CREATE TABLE IF NOT EXISTS Utilisateur (
     id INT AUTO_INCREMENT PRIMARY KEY,
     nom VARCHAR(255) NOT NULL,
-    role ENUM('DPO', 'Admin', 'Collaborateur') NOT NULL,
+    role ENUM('DPO', 'Admin', 'Collaborateur', 'SuperAdmin') NOT NULL,
     email VARCHAR(191) NOT NULL UNIQUE,  -- Réduit de 255 à 191 pour utf8mb4
     mot_de_passe VARCHAR(255) NOT NULL,
     actif BOOLEAN DEFAULT TRUE,
@@ -128,6 +128,7 @@ CREATE TABLE IF NOT EXISTS Rapport (
 -- Insertion de données d'exemple avec mots de passe hashés
 -- Mot de passe: "password123" hashé avec bcrypt
 INSERT INTO Utilisateur (nom, role, email, mot_de_passe) VALUES
+('Super Admin', 'SuperAdmin', 'super.admin@example.com', '$2a$10$DM29GNklacafTPWB.8BpIeDDJxMc8gri6uPvJkl3OEYAdCYDxFGDi'),
 ('Jean Dupont', 'DPO', 'jean.dupont@example.com', '$2b$10$rOzJqQjQjQjQjQjQjQjQjOzJqQjQjQjQjQjQjQjQjOzJqQjQjQjQjQ'),
 ('Marie Curie', 'Admin', 'marie.curie@example.com', '$2b$10$rOzJqQjQjQjQjQjQjQjQjOzJqQjQjQjQjQjQjQjQjOzJqQjQjQjQjQ'),
 ('Pierre Martin', 'Collaborateur', 'pierre.martin@example.com', '$2b$10$rOzJqQjQjQjQjQjQjQjQjOzJqQjQjQjQjQjQjQjQjOzJqQjQjQjQjQ');


### PR DESCRIPTION
## Summary
- add generic authorize middleware to enforce role checks
- restrict user management routes to Admin, DPO, or SuperAdmin
- extend schema with SuperAdmin role and provide SQL upgrade script

## Testing
- `cd backend && npm test >/tmp/test.log && tail -n 20 /tmp/test.log` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a719347168832fad76634154334f70