### PR TITLE
feat: add excel import and role checks

### DIFF
--- a/backend/routes/rapports.js
+++ b/backend/routes/rapports.js
@@ -2,11 +2,12 @@ const express = require("express")
 const router = express.Router()
 const db = require("../config/db")
 const auth = require("../middleware/auth")
+const authorize = require("../middleware/authorize")
 const PDFDocument = require("pdfkit")
 const XLSX = require("xlsx")
 
 // Générer un rapport de conformité
-router.get("/conformite", auth, async (req, res) => {
+router.get("/conformite", auth, authorize("Admin", "DPO", "SuperAdmin"), async (req, res) => {
   try {
     const [traitements] = await db.query(`
       SELECT t.*, COUNT(r.id) as nombre_risques, AVG(r.score_risque) as score_moyen
@@ -42,7 +43,7 @@ router.get("/conformite", auth, async (req, res) => {
 })
 
 // Exporter en PDF
-router.get("/conformite/pdf", auth, async (req, res) => {
+router.get("/conformite/pdf", auth, authorize("Admin", "DPO", "SuperAdmin"), async (req, res) => {
   try {
     const [traitements] = await db.query(`
       SELECT t.*, COUNT(r.id) as nombre_risques
@@ -75,7 +76,7 @@ router.get("/conformite/pdf", auth, async (req, res) => {
 })
 
 // Exporter en Excel
-router.get("/conformite/excel", auth, async (req, res) => {
+router.get("/conformite/excel", auth, authorize("Admin", "DPO", "SuperAdmin"), async (req, res) => {
   try {
     const [traitements] = await db.query(`
       SELECT t.nom, t.pole, t.base_legale, t.statut_conformite, t.duree_conservation,

--- a/frontend/app/dashboard/rapports/page.tsx
+++ b/frontend/app/dashboard/rapports/page.tsx
@@ -5,10 +5,11 @@ import { API_BASE_URL } from "@/lib/api"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { Badge } from "@/components/ui/badge"
-import { Download, FileText, BarChart3, Activity } from "lucide-react"
+import { Download, FileText, BarChart3, Activity, Upload } from "lucide-react"
 
 export default function RapportsPage() {
   const [loading, setLoading] = useState<string | null>(null)
+  const [file, setFile] = useState<File | null>(null)
 
   const handleExport = async (type: string, format: string) => {
     setLoading(`${type}-${format}`)
@@ -31,6 +32,28 @@ export default function RapportsPage() {
       }
     } catch (error) {
       console.error("Erreur lors de l'export:", error)
+    } finally {
+      setLoading(null)
+    }
+  }
+
+  const handleImport = async () => {
+    if (!file) return
+    setLoading("import")
+    try {
+      const token = localStorage.getItem("token")
+      const formData = new FormData()
+      formData.append("file", file)
+      const response = await fetch(`${API_BASE_URL}/api/traitements/import`, {
+        method: "POST",
+        headers: { "x-auth-token": token || "" },
+        body: formData,
+      })
+      if (response.ok) {
+        setFile(null)
+      }
+    } catch (error) {
+      console.error("Erreur lors de l'import:", error)
     } finally {
       setLoading(null)
     }
@@ -105,6 +128,28 @@ export default function RapportsPage() {
           </Card>
         ))}
       </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Importer un fichier Excel</CardTitle>
+          <CardDescription>Ajoutez des traitements depuis un fichier .xlsx</CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <input
+            type="file"
+            accept=".xlsx"
+            onChange={(e) => setFile(e.target.files?.[0] || null)}
+          />
+          <Button
+            onClick={handleImport}
+            disabled={!file || loading === "import"}
+            className="flex items-center"
+          >
+            <Upload className="mr-2 h-4 w-4" />
+            {loading === "import" ? "Import..." : "Importer"}
+          </Button>
+        </CardContent>
+      </Card>
 
       {/* Rapports personnalisés */}
       <Card>


### PR DESCRIPTION
## Summary
- add endpoint to import treatments from Excel and frontend upload card
- restrict report and treatment routes to specific roles

## Testing
- `npm test` (backend) *(fails: Missing script: "test")*
- `npm run lint` (backend) *(fails: Missing script: "lint")*
- `npm test` (frontend) *(fails: Missing script: "test")*
- `npm run lint` (frontend) *(interactive ESLint configuration prompt)*

------
https://chatgpt.com/codex/tasks/task_e_68a72054ab68832fb4c103dc6ada7c2c