### PR TITLE
feat: allow rapport role on protected routes

### DIFF
--- a/backend/routes/rapports.js
+++ b/backend/routes/rapports.js
@@ -7,7 +7,7 @@ const PDFDocument = require("pdfkit")
 const XLSX = require("xlsx")
 
 // Générer un rapport de conformité
-router.get("/conformite", auth, authorize("Admin", "DPO", "SuperAdmin"), async (req, res) => {
+router.get("/conformite", auth, authorize("Admin", "DPO", "SuperAdmin", "Rapport"), async (req, res) => {
   try {
     const [traitements] = await db.query(`
       SELECT t.*, COUNT(r.id) as nombre_risques, AVG(r.score_risque) as score_moyen
@@ -148,7 +148,7 @@ function exportReport(type, format, data, title, res) {
 router.get(
   "/conformite/:format",
   auth,
-  authorize("Admin", "DPO", "SuperAdmin"),
+  authorize("Admin", "DPO", "SuperAdmin", "Rapport"),
   async (req, res) => {
     try {
       const { data, title } = await buildReport("conformite")
@@ -163,7 +163,7 @@ router.get(
 router.get(
   "/risques/:format",
   auth,
-  authorize("Admin", "DPO", "SuperAdmin"),
+  authorize("Admin", "DPO", "SuperAdmin", "Rapport"),
   async (req, res) => {
     try {
       const { data, title } = await buildReport("risques")
@@ -178,7 +178,7 @@ router.get(
 router.get(
   "/activite/:format",
   auth,
-  authorize("Admin", "DPO", "SuperAdmin"),
+  authorize("Admin", "DPO", "SuperAdmin", "Rapport"),
   async (req, res) => {
     try {
       const { data, title } = await buildReport("activite")

--- a/backend/routes/traitements.js
+++ b/backend/routes/traitements.js
@@ -88,7 +88,7 @@ router.get("/:id", auth, async (req, res) => {
 })
 
 // Créer un traitement
-router.post("/", auth, authorize("Admin", "DPO", "SuperAdmin"), async (req, res) => {
+router.post("/", auth, authorize("Admin", "DPO", "SuperAdmin", "Rapport"), async (req, res) => {
   const {
     nom,
     pole,
@@ -153,7 +153,7 @@ router.post("/", auth, authorize("Admin", "DPO", "SuperAdmin"), async (req, res)
 })
 
 // Mettre à jour un traitement
-router.put("/:id", auth, authorize("Admin", "DPO", "SuperAdmin"), async (req, res) => {
+router.put("/:id", auth, authorize("Admin", "DPO", "SuperAdmin", "Rapport"), async (req, res) => {
   const {
     nom,
     pole,
@@ -209,7 +209,7 @@ router.put("/:id", auth, authorize("Admin", "DPO", "SuperAdmin"), async (req, re
 })
 
 // Supprimer un traitement
-router.delete("/:id", auth, authorize("Admin", "DPO", "SuperAdmin"), async (req, res) => {
+router.delete("/:id", auth, authorize("Admin", "DPO", "SuperAdmin", "Rapport"), async (req, res) => {
   try {
     await db.query("DELETE FROM Traitement WHERE id = ?", [req.params.id])
 
@@ -233,7 +233,7 @@ router.delete("/:id", auth, authorize("Admin", "DPO", "SuperAdmin"), async (req,
 router.post(
   "/import",
   auth,
-  authorize("Admin", "DPO", "SuperAdmin"),
+  authorize("Admin", "DPO", "SuperAdmin", "Rapport"),
   upload.single("file"),
   async (req, res) => {
     try {

--- a/backend/routes/users.js
+++ b/backend/routes/users.js
@@ -6,7 +6,7 @@ const auth = require("../middleware/auth")
 const authorize = require("../middleware/authorize")
 
 // Obtenir tous les utilisateurs
-router.get("/", auth, authorize("Admin", "DPO", "SuperAdmin"), async (req, res) => {
+router.get("/", auth, authorize("Admin", "DPO", "SuperAdmin", "Rapport"), async (req, res) => {
   try {
     const [users] = await db.query("SELECT id, nom, role, email, actif, cree_le FROM Utilisateur ORDER BY nom")
     res.json(users)
@@ -17,7 +17,7 @@ router.get("/", auth, authorize("Admin", "DPO", "SuperAdmin"), async (req, res) 
 })
 
 // Créer un utilisateur
-router.post("/", auth, authorize("Admin", "DPO", "SuperAdmin"), async (req, res) => {
+router.post("/", auth, authorize("Admin", "DPO", "SuperAdmin", "Rapport"), async (req, res) => {
   const { nom, role, email, mot_de_passe } = req.body
 
   try {
@@ -50,7 +50,7 @@ router.post("/", auth, authorize("Admin", "DPO", "SuperAdmin"), async (req, res)
 })
 
 // Mettre à jour un utilisateur
-router.put("/:id", auth, authorize("Admin", "DPO", "SuperAdmin"), async (req, res) => {
+router.put("/:id", auth, authorize("Admin", "DPO", "SuperAdmin", "Rapport"), async (req, res) => {
   const { nom, role, email, actif } = req.body
 
   try {


### PR DESCRIPTION
## Summary
- allow `Rapport` role to access report generation and export routes
- grant `Rapport` role access to user management and treatment endpoints

## Testing
- `npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_68a75ef1f9d0832fa9edf94ee68597ed