### PR TITLE
feat: implement rapport role access limits

### DIFF
--- a/backend/routes/users.js
+++ b/backend/routes/users.js
@@ -6,7 +6,7 @@ const auth = require("../middleware/auth")
 const authorize = require("../middleware/authorize")
 
 // Obtenir tous les utilisateurs
-router.get("/", auth, authorize("Admin", "DPO", "SuperAdmin", "Rapport"), async (req, res) => {
+router.get("/", auth, authorize("Admin", "DPO", "SuperAdmin"), async (req, res) => {
   try {
     const [users] = await db.query("SELECT id, nom, role, email, actif, cree_le FROM Utilisateur ORDER BY nom")
     res.json(users)
@@ -17,7 +17,7 @@ router.get("/", auth, authorize("Admin", "DPO", "SuperAdmin", "Rapport"), async 
 })
 
 // Créer un utilisateur
-router.post("/", auth, authorize("Admin", "DPO", "SuperAdmin", "Rapport"), async (req, res) => {
+router.post("/", auth, authorize("Admin", "DPO", "SuperAdmin"), async (req, res) => {
   const { nom, role, email, mot_de_passe } = req.body
 
   try {
@@ -50,7 +50,7 @@ router.post("/", auth, authorize("Admin", "DPO", "SuperAdmin", "Rapport"), async
 })
 
 // Mettre à jour un utilisateur
-router.put("/:id", auth, authorize("Admin", "DPO", "SuperAdmin", "Rapport"), async (req, res) => {
+router.put("/:id", auth, authorize("Admin", "DPO", "SuperAdmin"), async (req, res) => {
   const { nom, role, email, actif } = req.body
 
   try {

--- a/database/add_rapport_role.sql
+++ b/database/add_rapport_role.sql
@@ -1,0 +1,8 @@
+ALTER TABLE Utilisateur MODIFY role ENUM('DPO','Admin','Collaborateur','SuperAdmin','Rapport') NOT NULL;
+
+INSERT INTO Utilisateur (nom, role, email, mot_de_passe) VALUES
+('Rapporteur', 'Rapport', 'rapport.user@example.com', '$2a$10$DM29GNklacafTPWB.8BpIeDDJxMc8gri6uPvJkl3OEYAdCYDxFGDi');
+
+CREATE OR REPLACE VIEW vue_utilisateurs_public AS
+SELECT id, nom, role, email, actif, cree_le, mis_a_jour_le
+FROM Utilisateur;

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -8,7 +8,7 @@ USE smart_dpo;
 CREATE TABLE IF NOT EXISTS Utilisateur (
     id INT AUTO_INCREMENT PRIMARY KEY,
     nom VARCHAR(255) NOT NULL,
-    role ENUM('DPO', 'Admin', 'Collaborateur', 'SuperAdmin') NOT NULL,
+    role ENUM('DPO', 'Admin', 'Collaborateur', 'SuperAdmin', 'Rapport') NOT NULL,
     email VARCHAR(191) NOT NULL UNIQUE,  -- Réduit de 255 à 191 pour utf8mb4
     mot_de_passe VARCHAR(255) NOT NULL,
     actif BOOLEAN DEFAULT TRUE,
@@ -131,7 +131,8 @@ INSERT INTO Utilisateur (nom, role, email, mot_de_passe) VALUES
 ('Super Admin', 'SuperAdmin', 'super.admin@example.com', '$2a$10$DM29GNklacafTPWB.8BpIeDDJxMc8gri6uPvJkl3OEYAdCYDxFGDi'),
 ('Jean Dupont', 'DPO', 'jean.dupont@example.com', '$2b$10$rOzJqQjQjQjQjQjQjQjQjOzJqQjQjQjQjQjQjQjQjOzJqQjQjQjQjQ'),
 ('Marie Curie', 'Admin', 'marie.curie@example.com', '$2b$10$rOzJqQjQjQjQjQjQjQjQjOzJqQjQjQjQjQjQjQjQjOzJqQjQjQjQjQ'),
-('Pierre Martin', 'Collaborateur', 'pierre.martin@example.com', '$2b$10$rOzJqQjQjQjQjQjQjQjQjOzJqQjQjQjQjQjQjQjQjOzJqQjQjQjQjQ');
+('Pierre Martin', 'Collaborateur', 'pierre.martin@example.com', '$2b$10$rOzJqQjQjQjQjQjQjQjQjOzJqQjQjQjQjQjQjQjQjOzJqQjQjQjQjQ'),
+('Rapporteur', 'Rapport', 'rapport.user@example.com', '$2a$10$DM29GNklacafTPWB.8BpIeDDJxMc8gri6uPvJkl3OEYAdCYDxFGDi');
 
 INSERT INTO Traitement (nom, pole, base_legale, finalite, duree_conservation, type_dcp, nombre_personnes_concernees, utilisateur_id, statut_conformite) VALUES
 ('Gestion de la paie', 'RH', 'Obligation légale', 'Établir les bulletins de paie des employés', 5, 'Nom, prénom, adresse, numéro de sécurité sociale, salaire', 150, 1, 'Conforme'),

--- a/frontend/app/dashboard/users/page.tsx
+++ b/frontend/app/dashboard/users/page.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import { useState, useEffect } from "react"
+import { useRouter } from "next/navigation"
 import { API_BASE_URL } from "@/lib/api"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
@@ -19,7 +20,25 @@ export default function UsersPage() {
   const [showDialog, setShowDialog] = useState(false)
   const [editingUser, setEditingUser] = useState<any>(null)
 
+  const router = useRouter()
+
   useEffect(() => {
+    const stored = localStorage.getItem("user")
+    if (stored) {
+      try {
+        const current = JSON.parse(stored)
+        if (current.role === "Rapport" || current.role === "Collaborateur") {
+          router.push("/dashboard")
+          return
+        }
+      } catch {
+        router.push("/login")
+        return
+      }
+    } else {
+      router.push("/login")
+      return
+    }
     fetchUsers()
   }, [])
 

--- a/frontend/components/sidebar.tsx
+++ b/frontend/components/sidebar.tsx
@@ -4,6 +4,7 @@ import Link from "next/link"
 import { usePathname } from "next/navigation"
 import { cn } from "@/lib/utils"
 import Image from "next/image"
+import { useEffect, useState } from "react"
 import {
   ShieldCheck,
   FileText,
@@ -21,15 +22,29 @@ const navigation = [
   { name: "Traitements", href: "/dashboard/traitements", icon: FileText },
   { name: "Risques", href: "/dashboard/risques", icon: AlertTriangle },
   { name: "Mesures correctives", href: "/dashboard/mesures", icon: ShieldCheck },
-  { name: "Utilisateurs", href: "/dashboard/users", icon: Users },
+  { name: "Utilisateurs", href: "/dashboard/users", icon: Users, roles: ["Admin", "DPO", "SuperAdmin"] },
   { name: "Alertes", href: "/dashboard/alertes", icon: Bell },
   { name: "Journal", href: "/dashboard/journal", icon: BookOpen },
   { name: "Rapports", href: "/dashboard/rapports", icon: Download },
-  { name: "Paramètres", href: "/dashboard/settings", icon: Settings },
+  { name: "Paramètres", href: "/dashboard/settings", icon: Settings, roles: ["Admin", "DPO", "SuperAdmin"] },
 ]
 
 export function Sidebar() {
   const pathname = usePathname()
+  const [userRole, setUserRole] = useState<string | null>(null)
+
+  useEffect(() => {
+    const stored = localStorage.getItem("user")
+    if (stored) {
+      try {
+        setUserRole(JSON.parse(stored).role)
+      } catch {
+        setUserRole(null)
+      }
+    }
+  }, [])
+
+  const items = navigation.filter((item) => !item.roles || (userRole && item.roles.includes(userRole)))
 
   return (
     <div className="flex flex-col w-64 bg-white shadow-xl border-r border-gray-200">
@@ -49,7 +64,7 @@ export function Sidebar() {
       {/* Navigation */}
       <nav className="flex-1 px-4 py-6 space-y-2 overflow-y-auto">
         <div className="text-xs font-semibold text-gray-500 uppercase tracking-wider mb-4">Gestion RGPD</div>
-        {navigation.map((item) => {
+        {items.map((item) => {
           const isActive = pathname === item.href
           return (
             <Link


### PR DESCRIPTION
## Summary
- include Rapport in database schema and seed data
- hide Utilisateurs and Settings menu items from Rapport role
- block Rapport role from accessing user management endpoints
- redirect Rapport users away from user management page

## Testing
- `npm test` (frontend) *(fails: Missing script "test")*
- `npm run lint` *(prompts for ESLint configuration)*
- `npm run type-check` *(fails: Type 'string' is not assignable to type '"user" | "assistant"')*
- `npm test` (backend) *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a7a4c013b8832f829c72f231d0fa60