### PR TITLE
feat: enforce role-based access control

### DIFF
--- a/backend/routes/alertes.js
+++ b/backend/routes/alertes.js
@@ -2,9 +2,14 @@ const express = require("express")
 const router = express.Router()
 const db = require("../config/db")
 const auth = require("../middleware/auth")
+const authorize = require("../middleware/authorize")
 
 // Obtenir toutes les alertes
-router.get("/", auth, async (req, res) => {
+router.get(
+  "/",
+  auth,
+  authorize("Admin", "DPO", "SuperAdmin", "Collaborateur"),
+  async (req, res) => {
   try {
     const [alertes] = await db.query(`
       SELECT a.*, t.nom as nom_traitement, u.nom as nom_utilisateur
@@ -18,10 +23,15 @@ router.get("/", auth, async (req, res) => {
     console.error(err.message)
     res.status(500).send("Erreur serveur")
   }
-})
+  },
+)
 
 // Marquer une alerte comme lue
-router.put("/:id/read", auth, async (req, res) => {
+router.put(
+  "/:id/read",
+  auth,
+  authorize("Admin", "DPO", "SuperAdmin", "Collaborateur"),
+  async (req, res) => {
   try {
     await db.query("UPDATE Alerte SET lu = TRUE WHERE id = ?", [req.params.id])
     res.json({ msg: "Alerte marquée comme lue" })
@@ -29,6 +39,7 @@ router.put("/:id/read", auth, async (req, res) => {
     console.error(err.message)
     res.status(500).send("Erreur serveur")
   }
-})
+  },
+)
 
 module.exports = router

--- a/backend/routes/journal.js
+++ b/backend/routes/journal.js
@@ -2,9 +2,10 @@ const express = require("express")
 const router = express.Router()
 const db = require("../config/db")
 const auth = require("../middleware/auth")
+const authorize = require("../middleware/authorize")
 
 // Obtenir l'historique des actions
-router.get("/", auth, async (req, res) => {
+router.get("/", auth, authorize("Admin", "DPO", "SuperAdmin"), async (req, res) => {
   try {
     const [actions] = await db.query(`
       SELECT ja.*, u.nom as nom_utilisateur, t.nom as nom_traitement

--- a/backend/routes/mesures.js
+++ b/backend/routes/mesures.js
@@ -2,9 +2,14 @@ const express = require("express")
 const router = express.Router()
 const db = require("../config/db")
 const auth = require("../middleware/auth")
+const authorize = require("../middleware/authorize")
 
 // Obtenir toutes les mesures correctives
-router.get("/", auth, async (req, res) => {
+router.get(
+  "/",
+  auth,
+  authorize("Admin", "DPO", "SuperAdmin", "Collaborateur"),
+  async (req, res) => {
   try {
     const [mesures] = await db.query(`
       SELECT mc.*, r.traitement_id, t.nom as nom_traitement, u.nom as nom_responsable
@@ -19,10 +24,15 @@ router.get("/", auth, async (req, res) => {
     console.error(err.message)
     res.status(500).send("Erreur serveur")
   }
-})
+  },
+)
 
 // Créer une mesure corrective
-router.post("/", auth, async (req, res) => {
+router.post(
+  "/",
+  auth,
+  authorize("Admin", "DPO", "SuperAdmin", "Collaborateur"),
+  async (req, res) => {
   const { risque_id, description, type_mesure, priorite, responsable_id, date_echeance, cout_estime } = req.body
 
   try {
@@ -50,10 +60,15 @@ router.post("/", auth, async (req, res) => {
     console.error(err.message)
     res.status(500).send("Erreur serveur")
   }
-})
+  },
+)
 
 // Mettre à jour une mesure corrective
-router.put("/:id", auth, async (req, res) => {
+router.put(
+  "/:id",
+  auth,
+  authorize("Admin", "DPO", "SuperAdmin", "Collaborateur"),
+  async (req, res) => {
   const { description, type_mesure, priorite, statut, responsable_id, date_echeance, cout_estime } = req.body
 
   try {
@@ -72,6 +87,7 @@ router.put("/:id", auth, async (req, res) => {
     console.error(err.message)
     res.status(500).send("Erreur serveur")
   }
-})
+  },
+)
 
 module.exports = router

--- a/backend/routes/risques.js
+++ b/backend/routes/risques.js
@@ -2,9 +2,14 @@ const express = require("express")
 const router = express.Router()
 const db = require("../config/db")
 const auth = require("../middleware/auth")
+const authorize = require("../middleware/authorize")
 
 // Obtenir tous les risques
-router.get("/", auth, async (req, res) => {
+router.get(
+  "/",
+  auth,
+  authorize("Admin", "DPO", "SuperAdmin", "Collaborateur"),
+  async (req, res) => {
   try {
     const [risques] = await db.query(`
       SELECT r.*, t.nom as nom_traitement, t.pole
@@ -17,10 +22,15 @@ router.get("/", auth, async (req, res) => {
     console.error(err.message)
     res.status(500).send("Erreur serveur")
   }
-})
+  },
+)
 
 // Créer un risque
-router.post("/", auth, async (req, res) => {
+router.post(
+  "/",
+  auth,
+  authorize("Admin", "DPO", "SuperAdmin", "Collaborateur"),
+  async (req, res) => {
   const { traitement_id, type_risque, criticite, probabilite, impact, vulnerabilites, commentaire } = req.body
 
   try {
@@ -47,10 +57,15 @@ router.post("/", auth, async (req, res) => {
     console.error(err.message)
     res.status(500).send("Erreur serveur")
   }
-})
+  },
+)
 
 // Mettre à jour un risque
-router.put("/:id", auth, async (req, res) => {
+router.put(
+  "/:id",
+  auth,
+  authorize("Admin", "DPO", "SuperAdmin", "Collaborateur"),
+  async (req, res) => {
   const { type_risque, criticite, probabilite, impact, statut, vulnerabilites, commentaire } = req.body
 
   try {
@@ -79,6 +94,7 @@ router.put("/:id", auth, async (req, res) => {
     console.error(err.message)
     res.status(500).send("Erreur serveur")
   }
-})
+  },
+)
 
 module.exports = router

--- a/backend/routes/traitements.js
+++ b/backend/routes/traitements.js
@@ -10,7 +10,11 @@ const XLSX = require("xlsx")
 const upload = multer({ storage: multer.memoryStorage() })
 
 // Obtenir tous les traitements avec filtres
-router.get("/", auth, async (req, res) => {
+router.get(
+  "/",
+  auth,
+  authorize("Admin", "DPO", "SuperAdmin", "Collaborateur"),
+  async (req, res) => {
   try {
     const { pole, statut, base_legale, search } = req.query
 
@@ -50,10 +54,15 @@ router.get("/", auth, async (req, res) => {
     console.error(err.message)
     res.status(500).send("Erreur serveur")
   }
-})
+  },
+)
 
 // Obtenir un traitement par ID avec ses risques
-router.get("/:id", auth, async (req, res) => {
+router.get(
+  "/:id",
+  auth,
+  authorize("Admin", "DPO", "SuperAdmin", "Collaborateur"),
+  async (req, res) => {
   try {
     const [traitement] = await db.query(
       `
@@ -85,10 +94,15 @@ router.get("/:id", auth, async (req, res) => {
     console.error(err.message)
     res.status(500).send("Erreur serveur")
   }
-})
+  },
+)
 
 // Créer un traitement
-router.post("/", auth, authorize("Admin", "DPO", "SuperAdmin", "Rapport"), async (req, res) => {
+router.post(
+  "/",
+  auth,
+  authorize("Admin", "DPO", "SuperAdmin", "Collaborateur"),
+  async (req, res) => {
   const {
     nom,
     pole,
@@ -150,10 +164,15 @@ router.post("/", auth, authorize("Admin", "DPO", "SuperAdmin", "Rapport"), async
     console.error(err.message)
     res.status(500).send("Erreur serveur")
   }
-})
+  },
+)
 
 // Mettre à jour un traitement
-router.put("/:id", auth, authorize("Admin", "DPO", "SuperAdmin", "Rapport"), async (req, res) => {
+router.put(
+  "/:id",
+  auth,
+  authorize("Admin", "DPO", "SuperAdmin", "Collaborateur"),
+  async (req, res) => {
   const {
     nom,
     pole,
@@ -206,10 +225,15 @@ router.put("/:id", auth, authorize("Admin", "DPO", "SuperAdmin", "Rapport"), asy
     console.error(err.message)
     res.status(500).send("Erreur serveur")
   }
-})
+  },
+)
 
 // Supprimer un traitement
-router.delete("/:id", auth, authorize("Admin", "DPO", "SuperAdmin", "Rapport"), async (req, res) => {
+router.delete(
+  "/:id",
+  auth,
+  authorize("Admin", "DPO", "SuperAdmin", "Collaborateur"),
+  async (req, res) => {
   try {
     await db.query("DELETE FROM Traitement WHERE id = ?", [req.params.id])
 
@@ -227,13 +251,14 @@ router.delete("/:id", auth, authorize("Admin", "DPO", "SuperAdmin", "Rapport"), 
     console.error(err.message)
     res.status(500).send("Erreur serveur")
   }
-})
+  },
+)
 
 // Importer des traitements depuis un fichier Excel
 router.post(
   "/import",
   auth,
-  authorize("Admin", "DPO", "SuperAdmin", "Rapport"),
+  authorize("Admin", "DPO", "SuperAdmin", "Collaborateur"),
   upload.single("file"),
   async (req, res) => {
     try {

--- a/frontend/app/dashboard/alertes/page.tsx
+++ b/frontend/app/dashboard/alertes/page.tsx
@@ -6,14 +6,18 @@ import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { Badge } from "@/components/ui/badge"
 import { AlertTriangle, CheckCircle, Info, Clock } from "lucide-react"
+import { useRoleGuard } from "@/hooks/useRoleGuard"
 
 export default function AlertesPage() {
   const [alertes, setAlertes] = useState<any[]>([])
   const [loading, setLoading] = useState(true)
+  const role = useRoleGuard(["Admin", "DPO", "SuperAdmin", "Collaborateur"])
 
   useEffect(() => {
-    fetchAlertes()
-  }, [])
+    if (role) {
+      fetchAlertes()
+    }
+  }, [role])
 
   const fetchAlertes = async () => {
     try {

--- a/frontend/app/dashboard/journal/page.tsx
+++ b/frontend/app/dashboard/journal/page.tsx
@@ -7,6 +7,7 @@ import { Badge } from "@/components/ui/badge"
 import { Input } from "@/components/ui/input"
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
 import { Search, Activity, FileText, AlertTriangle, Shield, Calendar, User } from "lucide-react"
+import { useRoleGuard } from "@/hooks/useRoleGuard"
 
 export default function JournalPage() {
   const [actions, setActions] = useState<any[]>([])
@@ -15,9 +16,13 @@ export default function JournalPage() {
   const [searchTerm, setSearchTerm] = useState("")
   const [actionFilter, setActionFilter] = useState("all")
 
+  const role = useRoleGuard(["Admin", "DPO", "SuperAdmin"])
+
   useEffect(() => {
-    fetchActions()
-  }, [])
+    if (role) {
+      fetchActions()
+    }
+  }, [role])
 
   useEffect(() => {
     filterActions()

--- a/frontend/app/dashboard/mesures/page.tsx
+++ b/frontend/app/dashboard/mesures/page.tsx
@@ -10,6 +10,7 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@
 import { Plus, Search, Shield, CheckCircle, AlertTriangle, Clock, Edit } from "lucide-react"
 import { API_BASE_URL } from "@/lib/api"
 import { MesureDialog } from "@/components/mesure-dialog"
+import { useRoleGuard } from "@/hooks/useRoleGuard"
 
 export default function MesuresPage() {
   const [mesures, setMesures] = useState<any[]>([])
@@ -19,10 +20,13 @@ export default function MesuresPage() {
   const [filterStatus, setFilterStatus] = useState("all")
   const [showDialog, setShowDialog] = useState(false)
   const [editingMesure, setEditingMesure] = useState<any>(null)
+  const role = useRoleGuard(["Admin", "DPO", "SuperAdmin", "Collaborateur"])
 
   useEffect(() => {
-    fetchMesures()
-  }, [])
+    if (role) {
+      fetchMesures()
+    }
+  }, [role])
 
   useEffect(() => {
     filterMesures()

--- a/frontend/app/dashboard/rapports/page.tsx
+++ b/frontend/app/dashboard/rapports/page.tsx
@@ -6,10 +6,12 @@ import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { Badge } from "@/components/ui/badge"
 import { Download, FileText, BarChart3, Activity, Upload } from "lucide-react"
+import { useRoleGuard } from "@/hooks/useRoleGuard"
 
 export default function RapportsPage() {
   const [loading, setLoading] = useState<string | null>(null)
   const [file, setFile] = useState<File | null>(null)
+  useRoleGuard(["Admin", "DPO", "SuperAdmin", "Rapport"])
 
   const handleExport = async (type: string, format: string) => {
     setLoading(`${type}-${format}`)

--- a/frontend/app/dashboard/risques/page.tsx
+++ b/frontend/app/dashboard/risques/page.tsx
@@ -8,16 +8,20 @@ import { Badge } from "@/components/ui/badge"
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table"
 import { AlertTriangle, Plus, Eye, Edit } from "lucide-react"
 import { RisqueDialog } from "@/components/risque-dialog"
+import { useRoleGuard } from "@/hooks/useRoleGuard"
 
 export default function RisquesPage() {
   const [risques, setRisques] = useState<any[]>([])
   const [loading, setLoading] = useState(true)
   const [showDialog, setShowDialog] = useState(false)
   const [editingRisque, setEditingRisque] = useState<any>(null)
+  const role = useRoleGuard(["Admin", "DPO", "SuperAdmin", "Collaborateur"])
 
   useEffect(() => {
-    fetchRisques()
-  }, [])
+    if (role) {
+      fetchRisques()
+    }
+  }, [role])
 
   const fetchRisques = async () => {
     try {

--- a/frontend/app/dashboard/settings/page.tsx
+++ b/frontend/app/dashboard/settings/page.tsx
@@ -20,6 +20,7 @@ import {
   CheckCircle,
   Info,
 } from "lucide-react"
+import { useRoleGuard } from "@/hooks/useRoleGuard"
 
 export default function SettingsPage() {
   const [settings, setSettings] = useState({
@@ -53,6 +54,7 @@ export default function SettingsPage() {
 
   const [loading, setLoading] = useState(false)
   const [saved, setSaved] = useState(false)
+  useRoleGuard(["Admin", "DPO", "SuperAdmin"])
 
   const handleSave = async () => {
     setLoading(true)

--- a/frontend/app/dashboard/traitements/[id]/page.tsx
+++ b/frontend/app/dashboard/traitements/[id]/page.tsx
@@ -6,12 +6,15 @@ import { API_BASE_URL } from "@/lib/api"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { useRoleGuard } from "@/hooks/useRoleGuard"
 
 export default function TraitementDetailsPage({ params }: { params: { id: string } }) {
   const [traitement, setTraitement] = useState<any>(null)
   const [loading, setLoading] = useState(true)
+  const role = useRoleGuard(["Admin", "DPO", "SuperAdmin", "Collaborateur"])
 
   useEffect(() => {
+    if (!role) return
     const fetchTraitement = async () => {
       try {
         const token = localStorage.getItem("token")
@@ -30,7 +33,7 @@ export default function TraitementDetailsPage({ params }: { params: { id: string
     }
 
     fetchTraitement()
-  }, [params.id])
+  }, [params.id, role])
 
   if (loading) {
     return <div className="p-6">Chargement...</div>

--- a/frontend/app/dashboard/traitements/page.tsx
+++ b/frontend/app/dashboard/traitements/page.tsx
@@ -11,6 +11,7 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@
 import { PlusCircle, Search, Eye, Edit, Trash2 } from "lucide-react"
 import Link from "next/link"
 import { TraitementDialog } from "@/components/traitement-dialog"
+import { useRoleGuard } from "@/hooks/useRoleGuard"
 
 export default function TraitementsPage() {
   const [traitements, setTraitements] = useState<any[]>([])
@@ -21,10 +22,13 @@ export default function TraitementsPage() {
   const [poleFilter, setPoleFilter] = useState("all")
   const [showDialog, setShowDialog] = useState(false)
   const [editingTraitement, setEditingTraitement] = useState<any>(null)
+  const role = useRoleGuard(["Admin", "DPO", "SuperAdmin", "Collaborateur"])
 
   useEffect(() => {
-    fetchTraitements()
-  }, [])
+    if (role) {
+      fetchTraitements()
+    }
+  }, [role])
 
   useEffect(() => {
     filterTraitements()

--- a/frontend/app/dashboard/users/page.tsx
+++ b/frontend/app/dashboard/users/page.tsx
@@ -11,6 +11,7 @@ import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@
 import { Avatar, AvatarFallback } from "@/components/ui/avatar"
 import { Search, Edit, Trash2, UserPlus, Shield, UsersIcon } from "lucide-react"
 import { UserDialog } from "@/components/user-dialog"
+import { useRoleGuard } from "@/hooks/useRoleGuard"
 
 export default function UsersPage() {
   const [users, setUsers] = useState<any[]>([])
@@ -22,25 +23,13 @@ export default function UsersPage() {
 
   const router = useRouter()
 
+  const role = useRoleGuard(["Admin", "DPO", "SuperAdmin"])
+
   useEffect(() => {
-    const stored = localStorage.getItem("user")
-    if (stored) {
-      try {
-        const current = JSON.parse(stored)
-        if (current.role === "Rapport" || current.role === "Collaborateur") {
-          router.push("/dashboard")
-          return
-        }
-      } catch {
-        router.push("/login")
-        return
-      }
-    } else {
-      router.push("/login")
-      return
+    if (role) {
+      fetchUsers()
     }
-    fetchUsers()
-  }, [])
+  }, [role])
 
   useEffect(() => {
     filterUsers()

--- a/frontend/components/sidebar.tsx
+++ b/frontend/components/sidebar.tsx
@@ -18,14 +18,49 @@ import {
 } from "lucide-react"
 
 const navigation = [
-  { name: "Tableau de bord", href: "/dashboard", icon: BarChart3 },
-  { name: "Traitements", href: "/dashboard/traitements", icon: FileText },
-  { name: "Risques", href: "/dashboard/risques", icon: AlertTriangle },
-  { name: "Mesures correctives", href: "/dashboard/mesures", icon: ShieldCheck },
+  {
+    name: "Tableau de bord",
+    href: "/dashboard",
+    icon: BarChart3,
+    roles: ["Admin", "DPO", "SuperAdmin", "Collaborateur", "Rapport"],
+  },
+  {
+    name: "Traitements",
+    href: "/dashboard/traitements",
+    icon: FileText,
+    roles: ["Admin", "DPO", "SuperAdmin", "Collaborateur"],
+  },
+  {
+    name: "Risques",
+    href: "/dashboard/risques",
+    icon: AlertTriangle,
+    roles: ["Admin", "DPO", "SuperAdmin", "Collaborateur"],
+  },
+  {
+    name: "Mesures correctives",
+    href: "/dashboard/mesures",
+    icon: ShieldCheck,
+    roles: ["Admin", "DPO", "SuperAdmin", "Collaborateur"],
+  },
   { name: "Utilisateurs", href: "/dashboard/users", icon: Users, roles: ["Admin", "DPO", "SuperAdmin"] },
-  { name: "Alertes", href: "/dashboard/alertes", icon: Bell },
-  { name: "Journal", href: "/dashboard/journal", icon: BookOpen },
-  { name: "Rapports", href: "/dashboard/rapports", icon: Download },
+  {
+    name: "Alertes",
+    href: "/dashboard/alertes",
+    icon: Bell,
+    roles: ["Admin", "DPO", "SuperAdmin", "Collaborateur"],
+  },
+  {
+    name: "Journal",
+    href: "/dashboard/journal",
+    icon: BookOpen,
+    roles: ["Admin", "DPO", "SuperAdmin"],
+  },
+  {
+    name: "Rapports",
+    href: "/dashboard/rapports",
+    icon: Download,
+    roles: ["Admin", "DPO", "SuperAdmin", "Rapport"],
+  },
   { name: "Paramètres", href: "/dashboard/settings", icon: Settings, roles: ["Admin", "DPO", "SuperAdmin"] },
 ]
 

--- a/frontend/hooks/useRoleGuard.ts
+++ b/frontend/hooks/useRoleGuard.ts
@@ -1,0 +1,28 @@
+"use client"
+
+import { useRouter } from "next/navigation"
+import { useEffect, useState } from "react"
+
+export function useRoleGuard(allowedRoles: string[]) {
+  const [role, setRole] = useState<string | null>(null)
+  const router = useRouter()
+
+  useEffect(() => {
+    const stored = localStorage.getItem("user")
+    if (!stored) {
+      router.push("/login")
+      return
+    }
+    try {
+      const user = JSON.parse(stored)
+      setRole(user.role)
+      if (!allowedRoles.includes(user.role)) {
+        router.push("/dashboard")
+      }
+    } catch {
+      router.push("/login")
+    }
+  }, [allowedRoles, router])
+
+  return role
+}


### PR DESCRIPTION
## Summary
- add role guard hook for client side redirects
- hide navigation and pages based on role
- secure backend routes with role-based authorization

## Testing
- `cd backend && npm test`
- `cd frontend && npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68a7a8694c1c832f9be9c9adf14ae530