### PR TITLE
Allow report role to import treatments from Excel

### DIFF
--- a/backend/routes/traitements.js
+++ b/backend/routes/traitements.js
@@ -258,7 +258,7 @@ router.delete(
 router.post(
   "/import",
   auth,
-  authorize("Admin", "DPO", "SuperAdmin", "Collaborateur"),
+  authorize("Admin", "DPO", "SuperAdmin", "Collaborateur", "Rapport"),
   upload.single("file"),
   async (req, res) => {
     try {


### PR DESCRIPTION
## Summary
- permit 'Rapport' users to upload treatments from .xlsx files

## Testing
- `npm test` *(fails: Missing script: "test"*

------
https://chatgpt.com/codex/tasks/task_e_68a7aa476e94832f8f4a27f8a74a9ebe