### PR TITLE
Allow report role to import treatments from Excel

### DIFF
--- a/backend/routes/traitements.js
+++ b/backend/routes/traitements.js
@@ -258,7 +258,7 @@ router.delete(
 router.post(
   "/import",
   auth,
-  authorize("Admin", "DPO", "SuperAdmin", "Collaborateur"),
+  authorize("Admin", "DPO", "SuperAdmin", "Collaborateur", "Rapport"),
   upload.single("file"),
   async (req, res) => {
     try {

--- a/frontend/app/dashboard/rapports/page.tsx
+++ b/frontend/app/dashboard/rapports/page.tsx
@@ -11,7 +11,7 @@ import { useRoleGuard } from "@/hooks/useRoleGuard"
 export default function RapportsPage() {
   const [loading, setLoading] = useState<string | null>(null)
   const [file, setFile] = useState<File | null>(null)
-  useRoleGuard(["Admin", "DPO", "SuperAdmin", "Rapport"])
+  useRoleGuard(["Admin", "DPO", "SuperAdmin", "Collaborateur", "Rapport"])
 
   const handleExport = async (type: string, format: string) => {
     setLoading(`${type}-${format}`)

--- a/frontend/components/sidebar.tsx
+++ b/frontend/components/sidebar.tsx
@@ -59,7 +59,7 @@ const navigation = [
     name: "Rapports",
     href: "/dashboard/rapports",
     icon: Download,
-    roles: ["Admin", "DPO", "SuperAdmin", "Rapport"],
+    roles: ["Admin", "DPO", "SuperAdmin", "Collaborateur", "Rapport"],
   },
   { name: "Paramètres", href: "/dashboard/settings", icon: Settings, roles: ["Admin", "DPO", "SuperAdmin"] },
 ]


### PR DESCRIPTION
## Summary
- permit 'Rapport' users to upload treatments from .xlsx files
- allow 'Collaborateur' role to access report imports

## Testing
- `npm test` *(fails: Could not read package.json)*
- `npm test --prefix frontend` *(fails: Missing script: "test")*
- `npm test --prefix backend` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68a7aa476e94832f8f4a27f8a74a9ebe