### PR TITLE
feat: extend rapports with detailed measures

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Une application complète de gestion intelligente des risques RGPD pour les trai
 ### 📈 Rapports et Analytics
 - Rapport de conformité RGPD
 - Analyse des risques par criticité
+- Plan des mesures correctives avec suivi de l'échéance
 - Export PDF et Excel
 - Rapports automatiques programmés
 

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -116,7 +116,7 @@ CREATE TABLE IF NOT EXISTS Alerte (
 CREATE TABLE IF NOT EXISTS Rapport (
     id INT AUTO_INCREMENT PRIMARY KEY,
     titre VARCHAR(191) NOT NULL,  -- Réduit pour éviter les problèmes d'index
-    type_rapport ENUM('Conformité', 'Risques', 'Activité') NOT NULL,
+    type_rapport ENUM('Conformité', 'Risques', 'Activité', 'Mesures') NOT NULL,
     contenu JSON,
     genere_par INT,
     cree_le TIMESTAMP DEFAULT CURRENT_TIMESTAMP,

--- a/frontend/app/dashboard/rapports/page.tsx
+++ b/frontend/app/dashboard/rapports/page.tsx
@@ -5,7 +5,7 @@ import { API_BASE_URL } from "@/lib/api"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { Badge } from "@/components/ui/badge"
-import { Download, FileText, BarChart3, Activity, Upload } from "lucide-react"
+import { Download, FileText, BarChart3, Activity, Upload, ShieldCheck } from "lucide-react"
 import { useRoleGuard } from "@/hooks/useRoleGuard"
 
 export default function RapportsPage() {
@@ -82,6 +82,13 @@ export default function RapportsPage() {
       description: "Journal des actions et modifications récentes",
       icon: Activity,
       color: "bg-green-100 text-green-600",
+    },
+    {
+      id: "mesures",
+      title: "Plan des Mesures Correctives",
+      description: "Suivi détaillé des mesures correctives et leur statut",
+      icon: ShieldCheck,
+      color: "bg-purple-100 text-purple-600",
     },
   ]
 


### PR DESCRIPTION
## Summary
- expand report builder to include corrective measures
- show additional risk and status details in PDF exports
- expose measures report option in dashboard

## Testing
- `npm test` (backend) *(fails: Missing script "test")*
- `node --check routes/rapports.js`
- `npm test` (frontend) *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b80cac11d8832f8ca50e2fbe9576b5