### PR TITLE
fix: add basic toast hook for rapports page

### DIFF
--- a/frontend/components/ui/use-toast.ts
+++ b/frontend/components/ui/use-toast.ts
@@ -1,0 +1,20 @@
+"use client";
+
+export type ToastOptions = {
+  title: string;
+  description?: string;
+  variant?: "default" | "destructive";
+};
+
+export function useToast() {
+  const toast = ({ title, description }: ToastOptions) => {
+    const message = [title, description].filter(Boolean).join("\n");
+    if (typeof window !== "undefined") {
+      window.alert(message);
+    } else {
+      console.log(message);
+    }
+  };
+
+  return { toast };
+}


### PR DESCRIPTION
## Summary
- add simple `useToast` hook to replace missing module

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build` (fails: Failed to fetch font `Inter`, `JetBrains Mono`)


------
https://chatgpt.com/codex/tasks/task_e_68b818af0a14832fb186b6c2acd35baa