### PR TITLE
fix: normalize role for sidebar

### DIFF
--- a/frontend/components/sidebar.tsx
+++ b/frontend/components/sidebar.tsx
@@ -72,7 +72,9 @@ export function Sidebar() {
     const stored = localStorage.getItem("user")
     if (stored) {
       try {
-        setUserRole(JSON.parse(stored).role)
+        const parsed = JSON.parse(stored)
+        const role = typeof parsed.role === "string" ? parsed.role.toLowerCase().trim() : null
+        setUserRole(role)
       } catch {
         setUserRole(null)
       }


### PR DESCRIPTION
## Summary
- ensure role from local storage is normalized to lower case before use

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Next.js ESLint prompt)*
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_68b8207d2544832fa0a20e08e6bb425a