### PR TITLE
Allow DPO role universal access

### DIFF
--- a/backend/middleware/authorize.js
+++ b/backend/middleware/authorize.js
@@ -1,9 +1,17 @@
 const authorize = (...allowedRoles) => {
   return (req, res, next) => {
-    if (!req.user || !allowedRoles.includes(req.user.role)) {
+    if (!req.user) {
       return res.status(403).json({ msg: "Accès interdit: rôle insuffisant" })
     }
-    next()
+
+    const role = typeof req.user.role === "string" ? req.user.role.toLowerCase() : ""
+    const normalizedRoles = allowedRoles.map((r) => r.toLowerCase())
+
+    if (role === "dpo" || normalizedRoles.includes(role)) {
+      return next()
+    }
+
+    return res.status(403).json({ msg: "Accès interdit: rôle insuffisant" })
   }
 }
 

--- a/frontend/hooks/useRoleGuard.ts
+++ b/frontend/hooks/useRoleGuard.ts
@@ -15,8 +15,10 @@ export function useRoleGuard(allowedRoles: string[]) {
     }
     try {
       const user = JSON.parse(stored)
-      setRole(user.role)
-      if (!allowedRoles.includes(user.role)) {
+      const currentRole = typeof user.role === "string" ? user.role.toLowerCase() : ""
+      setRole(currentRole)
+      const normalizedRoles = allowedRoles.map((r) => r.toLowerCase())
+      if (currentRole !== "dpo" && !normalizedRoles.includes(currentRole)) {
         router.push("/dashboard")
       }
     } catch {


### PR DESCRIPTION
## Summary
- treat DPO as super-admin in backend authorization
- normalize roles client-side and bypass checks for DPO

## Testing
- `npm test` (backend) *(fails: Missing script "test")*
- `npm test` (frontend) *(fails: Missing script "test")*
- `npm run lint` (frontend) *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68b826e2ed14832f9b5ff9c48abd42a8