### PR TITLE
feat: add chat API route

### DIFF
--- a/frontend/app/api/chat/route.ts
+++ b/frontend/app/api/chat/route.ts
@@ -1,0 +1,25 @@
+import { NextResponse } from "next/server";
+
+export async function POST(req: Request) {
+  try {
+    const { model, messages } = await req.json();
+    const apiKey = process.env.GROQ_API_KEY;
+    if (!apiKey) {
+      return NextResponse.json({ error: "Missing GROQ_API_KEY" }, { status: 500 });
+    }
+
+    const res = await fetch("https://api.groq.com/openai/v1/chat/completions", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${apiKey}`,
+      },
+      body: JSON.stringify({ model, messages }),
+    });
+
+    const data = await res.json();
+    return NextResponse.json(data, { status: res.status });
+  } catch (error) {
+    return NextResponse.json({ error: "Failed to fetch chat response" }, { status: 500 });
+  }
+}


### PR DESCRIPTION
## Summary
- add proxy API route for chatbot requests via Groq

## Testing
- `npm test` (fails: Missing script)
- `npm run lint` (fails: prompts for ESLint config)

------
https://chatgpt.com/codex/tasks/task_e_68b8289c3108832f88a611805467f96e