### PR TITLE
chore: log groq api requests

### DIFF
--- a/frontend/app/api/chat/route.ts
+++ b/frontend/app/api/chat/route.ts
@@ -3,8 +3,11 @@ import { NextResponse } from "next/server";
 export async function POST(req: Request) {
   try {
     const { model, messages } = await req.json();
+    console.log("/api/chat request", { model, messages });
+
     const apiKey = process.env.GROQ_API_KEY;
     if (!apiKey) {
+      console.error("GROQ_API_KEY is missing");
       return NextResponse.json({ error: "Missing GROQ_API_KEY" }, { status: 500 });
     }
 
@@ -18,8 +21,13 @@ export async function POST(req: Request) {
     });
 
     const data = await res.json();
+    console.log("Groq response", { status: res.status, data });
     return NextResponse.json(data, { status: res.status });
   } catch (error) {
-    return NextResponse.json({ error: "Failed to fetch chat response" }, { status: 500 });
+    console.error("Error in /api/chat", error);
+    return NextResponse.json(
+      { error: "Failed to fetch chat response" },
+      { status: 500 }
+    );
   }
 }


### PR DESCRIPTION
## Summary
- add console logging to `/api/chat` for request payload, missing key, responses, and errors

## Testing
- `npm run lint` *(fails: interactive ESLint configuration prompt)*
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_68b829abd4ec832fb869430e12cf74a5