### PR TITLE
feat: make app name configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,10 +101,12 @@ Toutes les routes protégées utilisent les middlewares `auth` et `authorize` po
 - WAMP/XAMPP (pour le développement local)
 
 ### 1. Base de Données
-\`\`\`bash
-# Importer le schéma dans MySQL
+```bash
+# Importer le schéma et les paramètres d'application
 mysql -u root -p smart_dpo < database/schema.sql
-\`\`\`
+# Pour les installations existantes, initialiser la table ApplicationSettings
+mysql -u root -p smart_dpo < database/add_app_name_setting.sql
+```
 
 ### 2. Backend
 \`\`\`bash
@@ -136,6 +138,8 @@ DB_NAME=smart_dpo
 JWT_SECRET=votre_cle_secrete_jwt
 PORT=3001
 \`\`\`
+### Personnalisation du nom de l'application
+Le nom affiché dans l'interface (par défaut "Smart DPO") est stocké dans la table `ApplicationSettings`. Vous pouvez le modifier depuis la page **Paramètres** ou via l'endpoint `PUT /api/settings/app-name`.
 
 ### Accès par Défaut
 - **Email**: jean.dupont@example.com

--- a/backend/routes/settings.js
+++ b/backend/routes/settings.js
@@ -1,0 +1,34 @@
+const express = require("express")
+const router = express.Router()
+const db = require("../config/db")
+const auth = require("../middleware/auth")
+const authorize = require("../middleware/authorize")
+
+// Get application name
+router.get("/app-name", async (req, res) => {
+  try {
+    const [rows] = await db.query("SELECT app_name FROM ApplicationSettings LIMIT 1")
+    const appName = rows.length > 0 ? rows[0].app_name : "Smart DPO"
+    res.json({ appName })
+  } catch (err) {
+    console.error(err.message)
+    res.status(500).send("Erreur serveur")
+  }
+})
+
+// Update application name
+router.put("/app-name", auth, authorize("admin", "super admin"), async (req, res) => {
+  const { appName } = req.body
+  try {
+    await db.query(
+      "INSERT INTO ApplicationSettings (id, app_name) VALUES (1, ?) ON DUPLICATE KEY UPDATE app_name = VALUES(app_name)",
+      [appName]
+    )
+    res.json({ appName })
+  } catch (err) {
+    console.error(err.message)
+    res.status(500).send("Erreur serveur")
+  }
+})
+
+module.exports = router

--- a/backend/server.js
+++ b/backend/server.js
@@ -26,8 +26,14 @@ cron.schedule("0 * * * *", () => {
 })
 
 // Routes
-app.get("/", (req, res) => {
-  res.send("Smart DPO API is running...")
+app.get("/", async (req, res) => {
+  try {
+    const [rows] = await db.query("SELECT app_name FROM ApplicationSettings LIMIT 1")
+    const appName = rows.length > 0 ? rows[0].app_name : "Smart DPO"
+    res.send(`${appName} API is running...`)
+  } catch (err) {
+    res.send("API is running...")
+  }
 })
 
 app.use("/api/auth", require("./routes/auth"))
@@ -39,6 +45,7 @@ app.use("/api/journal", require("./routes/journal"))
 app.use("/api/alertes", require("./routes/alertes"))
 app.use("/api/rapports", require("./routes/rapports"))
 app.use("/api/dashboard", require("./routes/dashboard"))
+app.use("/api/settings", require("./routes/settings"))
 
 const PORT = process.env.PORT || 3001
 

--- a/database/add_app_name_setting.sql
+++ b/database/add_app_name_setting.sql
@@ -1,0 +1,11 @@
+-- Script to add application name setting
+USE smart_dpo;
+
+CREATE TABLE IF NOT EXISTS ApplicationSettings (
+    id INT PRIMARY KEY DEFAULT 1,
+    app_name VARCHAR(255) NOT NULL
+);
+
+INSERT INTO ApplicationSettings (id, app_name)
+VALUES (1, 'Smart DPO')
+ON DUPLICATE KEY UPDATE app_name = VALUES(app_name);

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -4,6 +4,16 @@ CREATE DATABASE IF NOT EXISTS smart_dpo CHARACTER SET utf8mb4 COLLATE utf8mb4_un
 -- Utilisation de la base de données
 USE smart_dpo;
 
+-- Table: ApplicationSettings
+CREATE TABLE IF NOT EXISTS ApplicationSettings (
+    id INT PRIMARY KEY DEFAULT 1,
+    app_name VARCHAR(255) NOT NULL
+);
+
+INSERT INTO ApplicationSettings (id, app_name)
+VALUES (1, 'Smart DPO')
+ON DUPLICATE KEY UPDATE app_name = VALUES(app_name);
+
 -- Table: Utilisateur
 CREATE TABLE IF NOT EXISTS Utilisateur (
     id INT AUTO_INCREMENT PRIMARY KEY,

--- a/frontend/app/dashboard/settings/page.tsx
+++ b/frontend/app/dashboard/settings/page.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useState } from "react"
+import { useState, useEffect } from "react"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { Input } from "@/components/ui/input"
@@ -21,6 +21,7 @@ import {
   Info,
 } from "lucide-react"
 import { useRoleGuard } from "@/hooks/useRoleGuard"
+import { API_BASE_URL } from "@/lib/api"
 
 export default function SettingsPage() {
   const [settings, setSettings] = useState({
@@ -52,6 +53,21 @@ export default function SettingsPage() {
     },
   })
 
+  const [appName, setAppName] = useState("Smart DPO")
+
+  useEffect(() => {
+    const fetchAppName = async () => {
+      try {
+        const res = await fetch(`${API_BASE_URL}/api/settings/app-name`)
+        const data = await res.json()
+        setAppName(data.appName)
+      } catch (error) {
+        console.error("Erreur lors du chargement du nom de l'application:", error)
+      }
+    }
+    fetchAppName()
+  }, [])
+
   const [loading, setLoading] = useState(false)
   const [saved, setSaved] = useState(false)
   useRoleGuard(["admin", "dpo", "super admin"])
@@ -59,7 +75,11 @@ export default function SettingsPage() {
   const handleSave = async () => {
     setLoading(true)
     try {
-      // Simulation de sauvegarde
+      await fetch(`${API_BASE_URL}/api/settings/app-name`, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ appName }),
+      })
       await new Promise((resolve) => setTimeout(resolve, 1000))
       setSaved(true)
       setTimeout(() => setSaved(false), 3000)
@@ -89,7 +109,7 @@ export default function SettingsPage() {
             <Settings className="mr-3 h-8 w-8 text-primary" />
             Paramètres
           </h1>
-          <p className="text-muted-foreground">Configurez votre application Smart DPO</p>
+          <p className="text-muted-foreground">Configurez votre application {appName}</p>
         </div>
         <Button onClick={handleSave} disabled={loading} className="shadow-lg">
           {loading ? (
@@ -244,6 +264,10 @@ export default function SettingsPage() {
           </CardHeader>
           <CardContent className="space-y-6">
             <div className="space-y-2">
+              <Label htmlFor="appName">Nom de l'application</Label>
+              <Input id="appName" value={appName} onChange={(e) => setAppName(e.target.value)} />
+            </div>
+            <div className="space-y-2">
               <Label htmlFor="language">Langue</Label>
               <Select
                 value={settings.system.language}
@@ -384,7 +408,7 @@ export default function SettingsPage() {
               <Info className="h-8 w-8 text-blue-600" />
               <div>
                 <h3 className="font-semibold text-blue-900">Version</h3>
-                <p className="text-sm text-blue-700">Smart DPO v1.0.0</p>
+                <p className="text-sm text-blue-700">{appName} v1.0.0</p>
               </div>
             </div>
           </CardContent>


### PR DESCRIPTION
## Summary
- allow renaming Smart DPO via new ApplicationSettings table and API
- expose routes to fetch and update app name and show dynamic name in API root
- add UI in settings page to view and change application name
- document how to initialize and modify the application name in README

## Testing
- `npm test` (backend) *(fails: Missing script)*
- `npm test` (frontend) *(fails: Missing script)*
- `npm run lint` (frontend) *(prompts for ESLint config)*

------
https://chatgpt.com/codex/tasks/task_e_68bea7b3ab60832fac7db6c69677778f