### PR TITLE
feat: enforce dashboard roles and add user stats

### DIFF
--- a/frontend/app/dashboard/page.tsx
+++ b/frontend/app/dashboard/page.tsx
@@ -29,6 +29,7 @@ import {
   Calendar,
   Activity,
   ArrowRight,
+  Users,
 } from "lucide-react"
 import Link from "next/link"
 
@@ -120,7 +121,7 @@ export default function DashboardPage() {
       </div>
 
       {/* Key Metrics */}
-      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-5 gap-6">
         <Card className="border-l-4 border-l-blue-500 hover:shadow-lg transition-shadow">
           <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
             <CardTitle className="text-sm font-medium text-gray-600">Total Traitements</CardTitle>
@@ -162,6 +163,19 @@ export default function DashboardPage() {
             </div>
             <Progress value={75} className="mt-3" />
             <div className="text-sm text-gray-600 mt-2">75% terminées</div>
+          </CardContent>
+        </Card>
+
+        <Card className="border-l-4 border-l-purple-500 hover:shadow-lg transition-shadow">
+          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+            <CardTitle className="text-sm font-medium text-gray-600">Utilisateurs</CardTitle>
+            <Users className="h-5 w-5 text-purple-500" />
+          </CardHeader>
+          <CardContent>
+            <div className="text-3xl font-bold text-gray-900">{stats?.totalUsers || 0}</div>
+            <div className="text-sm text-gray-600 mt-2">
+              {stats?.utilisateurs?.length || 0} rôles
+            </div>
           </CardContent>
         </Card>
 

--- a/frontend/components/sidebar.tsx
+++ b/frontend/components/sidebar.tsx
@@ -73,7 +73,10 @@ export function Sidebar() {
     if (stored) {
       try {
         const parsed = JSON.parse(stored)
-        const role = typeof parsed.role === "string" ? parsed.role.toLowerCase().trim() : null
+        const role =
+          typeof parsed.role === "string"
+            ? parsed.role.toLowerCase().replace(/_/g, " ").trim()
+            : null
         setUserRole(role)
       } catch {
         setUserRole(null)


### PR DESCRIPTION
## Summary
- normalize user role formatting to hide sidebar items for unauthorized roles
- restrict dashboard API routes by role and expose user statistics
- display total users on dashboard metrics

## Testing
- `npm test` (backend) *(fails: Missing script 'test')*
- `npm test` (frontend) *(fails: Missing script 'test')*
- `npm run lint` *(fails: requires interactive setup)*
- `npm run type-check`

------
https://chatgpt.com/codex/tasks/task_e_68c808898088832f8e0e7cf64db173e6