### PR TITLE
Fix user management actions and stats

### DIFF
--- a/backend/routes/users.js
+++ b/backend/routes/users.js
@@ -54,11 +54,13 @@ router.put("/:id", auth, authorize("admin", "dpo", "super admin"), async (req, r
   const { nom, role, email, actif } = req.body
 
   try {
+    const actifValue = typeof actif === "boolean" ? (actif ? 1 : 0) : actif
+
     await db.query("UPDATE Utilisateur SET nom = ?, role = ?, email = ?, actif = ? WHERE id = ?", [
       nom,
       role,
       email,
-      actif,
+      actifValue,
       req.params.id,
     ])
 
@@ -66,7 +68,29 @@ router.put("/:id", auth, authorize("admin", "dpo", "super admin"), async (req, r
       req.params.id,
     ])
 
+    if (updatedUser.length === 0) {
+      return res.status(404).json({ msg: "Utilisateur introuvable" })
+    }
+
     res.json(updatedUser[0])
+  } catch (err) {
+    console.error(err.message)
+    res.status(500).send("Erreur serveur")
+  }
+})
+
+// Supprimer un utilisateur
+router.delete("/:id", auth, authorize("admin", "dpo", "super admin"), async (req, res) => {
+  try {
+    const [existing] = await db.query("SELECT id FROM Utilisateur WHERE id = ?", [req.params.id])
+
+    if (existing.length === 0) {
+      return res.status(404).json({ msg: "Utilisateur introuvable" })
+    }
+
+    await db.query("DELETE FROM Utilisateur WHERE id = ?", [req.params.id])
+
+    res.json({ msg: "Utilisateur supprimé" })
   } catch (err) {
     console.error(err.message)
     res.status(500).send("Erreur serveur")

--- a/frontend/app/dashboard/users/page.tsx
+++ b/frontend/app/dashboard/users/page.tsx
@@ -1,7 +1,6 @@
 "use client"
 
 import { useState, useEffect } from "react"
-import { useRouter } from "next/navigation"
 import { API_BASE_URL } from "@/lib/api"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
@@ -21,8 +20,6 @@ export default function UsersPage() {
   const [showDialog, setShowDialog] = useState(false)
   const [editingUser, setEditingUser] = useState<any>(null)
 
-  const router = useRouter()
-
   const role = useRoleGuard(["admin", "dpo", "super admin"])
 
   useEffect(() => {
@@ -35,6 +32,8 @@ export default function UsersPage() {
     filterUsers()
   }, [users, searchTerm])
 
+  const normalizeRole = (role: string | null | undefined) => role?.toLowerCase().trim() || ""
+
   const fetchUsers = async () => {
     try {
       const token = localStorage.getItem("token")
@@ -43,7 +42,12 @@ export default function UsersPage() {
       })
       if (res.ok) {
         const data = await res.json()
-        setUsers(data)
+        const formatted = data.map((user: any) => ({
+          ...user,
+          role: user.role || "",
+          actif: Boolean(user.actif),
+        }))
+        setUsers(formatted)
       }
     } catch (error) {
       console.error("Erreur lors de la récupération des utilisateurs:", error)
@@ -58,8 +62,8 @@ export default function UsersPage() {
     if (searchTerm) {
       filtered = filtered.filter(
         (u) =>
-          u.nom.toLowerCase().includes(searchTerm.toLowerCase()) ||
-          u.email.toLowerCase().includes(searchTerm.toLowerCase()),
+          (u.nom || "").toLowerCase().includes(searchTerm.toLowerCase()) ||
+          (u.email || "").toLowerCase().includes(searchTerm.toLowerCase()),
       )
     }
 
@@ -84,7 +88,7 @@ export default function UsersPage() {
   }
 
   const getRoleBadge = (role: string) => {
-    switch (role) {
+    switch (normalizeRole(role)) {
       case "dpo":
         return (
           <Badge className="bg-purple-100 text-purple-800">
@@ -124,8 +128,13 @@ export default function UsersPage() {
   }
 
   const getInitials = (nom: string) => {
+    if (!nom) {
+      return ""
+    }
+
     return nom
       .split(" ")
+      .filter(Boolean)
       .map((n) => n[0])
       .join("")
       .toUpperCase()
@@ -161,7 +170,7 @@ export default function UsersPage() {
             <div className="flex items-center justify-between">
               <div>
                 <p className="text-sm font-medium text-muted-foreground">DPO</p>
-                <p className="text-2xl font-bold">{users.filter((u) => u.role === "dpo").length}</p>
+                <p className="text-2xl font-bold">{users.filter((u) => normalizeRole(u.role) === "dpo").length}</p>
               </div>
               <Shield className="h-8 w-8 text-purple-500" />
             </div>
@@ -172,7 +181,7 @@ export default function UsersPage() {
             <div className="flex items-center justify-between">
               <div>
                 <p className="text-sm font-medium text-muted-foreground">Admins</p>
-                <p className="text-2xl font-bold">{users.filter((u) => u.role === "admin").length}</p>
+                <p className="text-2xl font-bold">{users.filter((u) => normalizeRole(u.role) === "admin").length}</p>
               </div>
               <UsersIcon className="h-8 w-8 text-blue-500" />
             </div>
@@ -183,7 +192,7 @@ export default function UsersPage() {
             <div className="flex items-center justify-between">
               <div>
                 <p className="text-sm font-medium text-muted-foreground">Responsables du traitement</p>
-                <p className="text-2xl font-bold">{users.filter((u) => u.role === "responsable du traitement").length}</p>
+                <p className="text-2xl font-bold">{users.filter((u) => normalizeRole(u.role) === "responsable du traitement").length}</p>
               </div>
               <UsersIcon className="h-8 w-8 text-green-500" />
             </div>
@@ -255,7 +264,7 @@ export default function UsersPage() {
                   </TableCell>
                   <TableCell className="text-muted-foreground">{user.email}</TableCell>
                   <TableCell>{getRoleBadge(user.role)}</TableCell>
-                  <TableCell>{getStatusBadge(user.actif)}</TableCell>
+                  <TableCell>{getStatusBadge(Boolean(user.actif))}</TableCell>
                   <TableCell className="text-muted-foreground">
                     {new Date(user.cree_le).toLocaleDateString("fr-FR")}
                   </TableCell>

--- a/frontend/components/user-dialog.tsx
+++ b/frontend/components/user-dialog.tsx
@@ -41,7 +41,7 @@ export function UserDialog({ open, onOpenChange, user, onSuccess }: UserDialogPr
         nom: user.nom || "",
         email: user.email || "",
         role: user.role || "responsable du traitement",
-        actif: user.actif !== undefined ? user.actif : true,
+        actif: user.actif !== undefined ? Boolean(user.actif) : true,
         mot_de_passe: "",
       })
     } else {


### PR DESCRIPTION
## Summary
- normalize role handling on the user dashboard so the statistics and badges match stored data
- ensure user dialog treats the active flag as a boolean for editing existing entries
- convert boolean flags during updates and expose a delete endpoint so user CRUD works again

## Testing
- `npm run lint` *(fails: command prompts for interactive configuration in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d7d6f82370832fa5ed7c8fc3e11cdd