### PR TITLE
Fix user role updates for profile edits

### DIFF
--- a/backend/routes/users.js
+++ b/backend/routes/users.js
@@ -54,13 +54,32 @@ router.put("/:id", auth, authorize("admin", "dpo", "super admin"), async (req, r
   const { nom, role, email, actif } = req.body
 
   try {
-    const actifValue = typeof actif === "boolean" ? (actif ? 1 : 0) : actif
+    const [existingUser] = await db.query("SELECT nom, role, email, actif FROM Utilisateur WHERE id = ?", [
+      req.params.id,
+    ])
+
+    if (existingUser.length === 0) {
+      return res.status(404).json({ msg: "Utilisateur introuvable" })
+    }
+
+    const currentUser = existingUser[0]
+
+    const updatedNom = typeof nom === "string" && nom.length > 0 ? nom : currentUser.nom
+    const updatedRole = typeof role === "string" && role.length > 0 ? role : currentUser.role
+    const updatedEmail = typeof email === "string" && email.length > 0 ? email : currentUser.email
+
+    const actifValue =
+      typeof actif === "boolean"
+        ? actif
+        : actif !== undefined && actif !== null
+          ? Boolean(actif)
+          : Boolean(currentUser.actif)
 
     await db.query("UPDATE Utilisateur SET nom = ?, role = ?, email = ?, actif = ? WHERE id = ?", [
-      nom,
-      role,
-      email,
-      actifValue,
+      updatedNom,
+      updatedRole,
+      updatedEmail,
+      actifValue ? 1 : 0,
       req.params.id,
     ])
 

--- a/frontend/app/profile/edit/page.tsx
+++ b/frontend/app/profile/edit/page.tsx
@@ -12,6 +12,8 @@ export default function EditProfilePage() {
   const [nom, setNom] = useState("")
   const [email, setEmail] = useState("")
   const [userId, setUserId] = useState<number | null>(null)
+  const [role, setRole] = useState<string | null>(null)
+  const [actif, setActif] = useState<boolean>(true)
 
   useEffect(() => {
     const stored = localStorage.getItem("user")
@@ -20,6 +22,8 @@ export default function EditProfilePage() {
       setNom(u.nom || "")
       setEmail(u.email || "")
       setUserId(u.id)
+      setRole(typeof u.role === "string" ? u.role : null)
+      setActif(u.actif !== undefined ? Boolean(u.actif) : true)
     }
   }, [])
 
@@ -28,13 +32,24 @@ export default function EditProfilePage() {
     if (!userId) return
     const token = localStorage.getItem("token")
     try {
+      const payload: Record<string, unknown> = {
+        nom,
+        email,
+      }
+
+      if (typeof role === "string") {
+        payload.role = role
+      }
+
+      payload.actif = actif
+
       const res = await fetch(`${API_BASE_URL}/api/users/${userId}`, {
         method: "PUT",
         headers: {
           "Content-Type": "application/json",
           "x-auth-token": token || "",
         },
-        body: JSON.stringify({ nom, email }),
+        body: JSON.stringify(payload),
       })
       if (res.ok) {
         const updated = await res.json()


### PR DESCRIPTION
## Summary
- guard the user update endpoint against missing fields by loading the current record before applying changes
- ensure the profile edit form preserves the existing role and activation flag when saving

## Testing
- npm run lint *(fails: requires interactive ESLint configuration prompt)*

------
https://chatgpt.com/codex/tasks/task_e_68d7d910e0e0832f8809b7b0fc396494