### PR TITLE
Allow non-admin roles to view user list

### DIFF
--- a/backend/routes/users.js
+++ b/backend/routes/users.js
@@ -6,7 +6,11 @@ const auth = require("../middleware/auth")
 const authorize = require("../middleware/authorize")
 
 // Obtenir tous les utilisateurs
-router.get("/", auth, authorize("admin", "dpo", "super admin"), async (req, res) => {
+router.get(
+  "/",
+  auth,
+  authorize("admin", "dpo", "super admin", "responsable du traitement", "sous traitant"),
+  async (req, res) => {
   try {
     const [users] = await db.query("SELECT id, nom, role, email, actif, cree_le FROM Utilisateur ORDER BY nom")
     res.json(users)
@@ -14,7 +18,8 @@ router.get("/", auth, authorize("admin", "dpo", "super admin"), async (req, res)
     console.error(err.message)
     res.status(500).send("Erreur serveur")
   }
-})
+  },
+)
 
 // Créer un utilisateur
 router.post("/", auth, authorize("admin", "dpo", "super admin"), async (req, res) => {

--- a/frontend/app/dashboard/users/page.tsx
+++ b/frontend/app/dashboard/users/page.tsx
@@ -20,7 +20,7 @@ export default function UsersPage() {
   const [showDialog, setShowDialog] = useState(false)
   const [editingUser, setEditingUser] = useState<any>(null)
 
-  const role = useRoleGuard(["admin", "dpo", "super admin"])
+  const role = useRoleGuard(["admin", "dpo", "super admin", "responsable du traitement", "sous traitant"])
 
   useEffect(() => {
     if (role) {
@@ -86,6 +86,9 @@ export default function UsersPage() {
 
     return normalized.replace(/\b\w/g, (letter) => letter.toUpperCase())
   }
+
+  const normalizedCurrentRole = normalizeRole(role)
+  const canManageUsers = ["admin", "dpo", "super admin"].includes(normalizedCurrentRole)
 
   const fetchUsers = async () => {
     try {
@@ -218,10 +221,12 @@ export default function UsersPage() {
           <h1 className="text-3xl font-bold tracking-tight">Gestion des Utilisateurs</h1>
           <p className="text-muted-foreground">Gérez les accès et les rôles de votre équipe</p>
         </div>
-        <Button onClick={() => setShowDialog(true)} className="shadow-lg">
-          <UserPlus className="mr-2 h-4 w-4" />
-          Nouvel Utilisateur
-        </Button>
+        {canManageUsers && (
+          <Button onClick={() => setShowDialog(true)} className="shadow-lg">
+            <UserPlus className="mr-2 h-4 w-4" />
+            Nouvel Utilisateur
+          </Button>
+        )}
       </div>
 
       {/* Stats Cards */}
@@ -305,7 +310,7 @@ export default function UsersPage() {
                 <TableHead>Rôle</TableHead>
                 <TableHead>Statut</TableHead>
                 <TableHead>Créé le</TableHead>
-                <TableHead className="text-right">Actions</TableHead>
+                {canManageUsers && <TableHead className="text-right">Actions</TableHead>}
               </TableRow>
             </TableHeader>
             <TableBody>
@@ -329,29 +334,31 @@ export default function UsersPage() {
                   <TableCell className="text-muted-foreground">
                     {new Date(user.cree_le).toLocaleDateString("fr-FR")}
                   </TableCell>
-                  <TableCell className="text-right">
-                    <div className="flex items-center justify-end space-x-2">
-                      <Button
-                        variant="ghost"
-                        size="sm"
-                        onClick={() => {
-                          setEditingUser(user)
-                          setShowDialog(true)
-                        }}
-                        className="hover:bg-blue-50 hover:text-blue-600"
-                      >
-                        <Edit className="h-4 w-4" />
-                      </Button>
-                      <Button
-                        variant="ghost"
-                        size="sm"
-                        onClick={() => handleDelete(user.id)}
-                        className="hover:bg-red-50 hover:text-red-600"
-                      >
-                        <Trash2 className="h-4 w-4" />
-                      </Button>
-                    </div>
-                  </TableCell>
+                  {canManageUsers && (
+                    <TableCell className="text-right">
+                      <div className="flex items-center justify-end space-x-2">
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          onClick={() => {
+                            setEditingUser(user)
+                            setShowDialog(true)
+                          }}
+                          className="hover:bg-blue-50 hover:text-blue-600"
+                        >
+                          <Edit className="h-4 w-4" />
+                        </Button>
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          onClick={() => handleDelete(user.id)}
+                          className="hover:bg-red-50 hover:text-red-600"
+                        >
+                          <Trash2 className="h-4 w-4" />
+                        </Button>
+                      </div>
+                    </TableCell>
+                  )}
                 </TableRow>
               ))}
             </TableBody>
@@ -359,16 +366,18 @@ export default function UsersPage() {
         </CardContent>
       </Card>
 
-      <UserDialog
-        open={showDialog}
-        onOpenChange={setShowDialog}
-        user={editingUser}
-        onSuccess={() => {
-          fetchUsers()
-          setShowDialog(false)
-          setEditingUser(null)
-        }}
-      />
+      {canManageUsers && (
+        <UserDialog
+          open={showDialog}
+          onOpenChange={setShowDialog}
+          user={editingUser}
+          onSuccess={() => {
+            fetchUsers()
+            setShowDialog(false)
+            setEditingUser(null)
+          }}
+        />
+      )}
     </div>
   )
 }

--- a/frontend/components/sidebar.tsx
+++ b/frontend/components/sidebar.tsx
@@ -42,7 +42,12 @@ const navigation = [
     icon: ShieldCheck,
     roles: ["admin", "dpo", "super admin", "responsable du traitement"],
   },
-  { name: "Utilisateurs", href: "/dashboard/users", icon: Users, roles: ["admin", "dpo", "super admin"] },
+  {
+    name: "Utilisateurs",
+    href: "/dashboard/users",
+    icon: Users,
+    roles: ["admin", "dpo", "super admin", "responsable du traitement", "sous traitant"],
+  },
   {
     name: "Alertes",
     href: "/dashboard/alertes",


### PR DESCRIPTION
## Summary
- allow responsables du traitement and sous-traitant roles to fetch the users list through the API and sidebar navigation
- extend the users dashboard page guard to admit these roles while restricting management actions to admins, DPOs, and super admins
- hide creation and row action controls for read-only roles to preserve permissions

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d7dec07b70832fb2b086f861446f42