### PR TITLE
Ensure user role enum supports all application roles

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -4,6 +4,7 @@ const cors = require("cors")
 const cron = require("node-cron")
 const db = require("./config/db")
 const { checkAlerts } = require("./services/alertService")
+const { ensureRoleEnumValues } = require("./services/userSetup")
 
 const app = express()
 
@@ -13,9 +14,15 @@ app.use(express.json())
 
 // Test de la connexion à la base de données
 db.getConnection()
-  .then((connection) => {
+  .then(async (connection) => {
     console.log("MySQL Connected...")
     connection.release()
+
+    try {
+      await ensureRoleEnumValues()
+    } catch (setupError) {
+      console.error("Erreur lors de la configuration initiale des rôles:", setupError)
+    }
   })
   .catch((err) => console.error("Error connecting to MySQL:", err))
 

--- a/backend/services/userSetup.js
+++ b/backend/services/userSetup.js
@@ -1,0 +1,52 @@
+const db = require("../config/db")
+
+const REQUIRED_ROLE_VALUES = [
+  "dpo",
+  "admin",
+  "responsable du traitement",
+  "super admin",
+  "sous traitant",
+]
+
+function extractEnumValues(typeDefinition) {
+  if (!typeDefinition) {
+    return []
+  }
+
+  const matches = [...typeDefinition.matchAll(/'([^']+)'/g)]
+  return matches.map((match) => match[1])
+}
+
+async function ensureRoleEnumValues() {
+  try {
+    const [rows] = await db.query("SHOW COLUMNS FROM Utilisateur LIKE 'role'")
+
+    if (!rows || rows.length === 0) {
+      return
+    }
+
+    const columnType = rows[0].Type
+    const existingValues = extractEnumValues(columnType)
+
+    const missingValues = REQUIRED_ROLE_VALUES.filter((role) => !existingValues.includes(role))
+
+    if (missingValues.length === 0) {
+      return
+    }
+
+    const mergedValues = Array.from(new Set([...existingValues, ...REQUIRED_ROLE_VALUES]))
+    const enumDefinition = mergedValues.map((role) => db.escape(role)).join(", ")
+
+    await db.query(`ALTER TABLE Utilisateur MODIFY role ENUM(${enumDefinition}) NOT NULL`)
+
+    console.log(
+      `Mise à jour du champ Utilisateur.role pour inclure les rôles manquants: ${missingValues.join(", ")}`,
+    )
+  } catch (error) {
+    console.error("Erreur lors de la vérification des rôles autorisés:", error)
+  }
+}
+
+module.exports = {
+  ensureRoleEnumValues,
+}


### PR DESCRIPTION
## Summary
- add a startup check that keeps the Utilisateur.role enum aligned with the roles used by the app
- log when missing roles are added so administrators can track automatic schema adjustments

## Testing
- not run (not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68d7e82c7ff0832fbd6cca04cf92cbb6